### PR TITLE
Update manifest.json

### DIFF
--- a/template/static/manifest.json
+++ b/template/static/manifest.json
@@ -3,12 +3,12 @@
   "short_name": "{{#if short_name }}{{ short_name }}{{else}}{{ name }}{{/if}}",
   "icons": [
     {
-      "src": "/static/img/icons/android-chrome-192x192.png",
+      "src": "img/icons/android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/static/img/icons/android-chrome-512x512.png",
+      "src": "img/icons/android-chrome-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }


### PR DESCRIPTION
Since manifest is severed from "static" folder, the proper root for images would be src="img/path-to-image.png"

This ensures that images resolve correctly if you set `build.assetsPublicPath`  to  "", e.g. when hosing from virtual directory like : `http::/localhost/demo`